### PR TITLE
Treat rtModules/ and modules/ in the same way

### DIFF
--- a/lib/ts2gamesparks.js
+++ b/lib/ts2gamesparks.js
@@ -48,8 +48,8 @@ function buildFile(tsConfig, services, fileName) {
     }
     assert(!!tsConfig.options.baseUrl, "tsconfig.json: !baseUrl");
     var relativePath = path.relative(tsConfig.options.baseUrl, fileName);
-    var isInModules = relativePath.indexOf("..") == -1;
-    var moduleName = path.basename(isInModules ? replaceSeparator(relativePath) : fileName, ".ts");
+    var isInModules = relativePath.indexOf("modules/") == 0 || relativePath.indexOf("rtModules/") == 0;
+    var moduleName = path.basename(isInModules ? replaceSeparator(relativePath.replace(/^(rtM|m)odules\//, "")) : fileName, ".ts");
     function replaceSeparator(name) {
         return name.replace(new RegExp("/", "g"), "__");
     }
@@ -179,7 +179,7 @@ function buildFile(tsConfig, services, fileName) {
             var o = _b[_a];
             var jsPath = o.name;
             if (isInModules) {
-                var relativePathJs = relativePath.replace(".ts", ".js");
+                var relativePathJs = relativePath.replace(/^(rtM|m)odules\//, "").replace(".ts", ".js");
                 jsPath = o.name.replace(relativePathJs, replaceSeparator(relativePathJs));
             }
             mkdirp.sync(path.dirname(jsPath));
@@ -187,10 +187,8 @@ function buildFile(tsConfig, services, fileName) {
             console.log(path.relative(process.cwd(), fileName) + " => " + path.relative(process.cwd(), jsPath));
         }
     }
-    if (path.dirname(fileName).split("/").pop() != "rtScript") {
-        doRenaming();
-        doRefactoring();
-    }
+    doRenaming();
+    doRefactoring();
     doOutput();
 }
 var tsConfig = getTsConfig();
@@ -201,3 +199,4 @@ for (var _i = 0, _a = tsConfig.fileNames; _i < _a.length; _i++) {
     var fileName = _a[_i];
     buildFile(tsConfig, services, fileName);
 }
+//# sourceMappingURL=ts2gamesparks.js.map

--- a/src/ts2gamesparks.ts
+++ b/src/ts2gamesparks.ts
@@ -57,8 +57,8 @@ function buildFile(tsConfig: ts.ParsedCommandLine, services: ts.LanguageService,
 
 	assert(!!tsConfig.options.baseUrl, "tsconfig.json: !baseUrl");
 	const relativePath = path.relative(tsConfig.options.baseUrl, fileName); // ../event/eventA.ts | moduleA.ts | folder/moduleB.ts
-	const isInModules = relativePath.indexOf("..") == -1; // in "modules/"
-	const moduleName = path.basename(isInModules ? replaceSeparator(relativePath) : fileName, ".ts"); // "moduleA" | "folder__moduleB" | "eventA" | "eventB"
+	const isInModules = relativePath.indexOf("modules/") == 0 || relativePath.indexOf("rtModules/") == 0; // in "modules/" or in rtModules/
+	const moduleName = path.basename(isInModules ? replaceSeparator(relativePath.replace(/^(rtM|m)odules\//, "")) : fileName, ".ts"); // "moduleA" | "folder__moduleB" | "eventA" | "eventB"
 
 	interface RenameInfo {
 		renameLocation: ts.RenameLocation,
@@ -295,7 +295,7 @@ function buildFile(tsConfig: ts.ParsedCommandLine, services: ts.LanguageService,
 				 * // after
 				 * "dict/modules/folder__moduleA.js"
 				 */
-				const relativePathJs = relativePath.replace(".ts", ".js");
+				const relativePathJs = relativePath.replace(/^(rtM|m)odules\//, "").replace(".ts", ".js");
 				jsPath = o.name.replace(relativePathJs, replaceSeparator(relativePathJs));
 			}
 			mkdirp.sync(path.dirname(jsPath));
@@ -304,10 +304,8 @@ function buildFile(tsConfig: ts.ParsedCommandLine, services: ts.LanguageService,
 		}
 	}
 
-    if (path.dirname(fileName).split("/").pop() != "rtScript") {
-		doRenaming();
-		doRefactoring();
-	}
+	doRenaming();
+	doRefactoring();
 	doOutput();
 }
 

--- a/src/ts2gamesparks.ts
+++ b/src/ts2gamesparks.ts
@@ -304,8 +304,10 @@ function buildFile(tsConfig: ts.ParsedCommandLine, services: ts.LanguageService,
 		}
 	}
 
-	doRenaming();
-	doRefactoring();
+	if (!/^rtModules\/|^rtScript\//.test(relativePath)) {
+		doRenaming();
+		doRefactoring();
+	}
 	doOutput();
 }
 


### PR DESCRIPTION
AFAIK Gamesparks treats rtModules in the same way as standard modules and rtScript like the other standard CloudCode scripts (events, requests, etc).
This should be a valid approach for transpiling, too. 

My PR does that and treats modules under rtModules/ like they were under modules/

rtModules and modules must be the same also at typescirpt level and thus tsconfig.json must be configured in the following way

```json
{
  "compilerOptions": {
    "target": "es5",
    "module": "commonjs",
    "lib": ["es5", "es2015"],
    "forceConsistentCasingInFileNames": true,
    "skipLibCheck": true,
    "rootDir": "./src",
    "outDir": "./dist/",
    "baseUrl": "./src/",
    "paths": {
      "*": [
        "./modules/*",
        "./rtModules/*",
      ],
    }
  },
  "include": [
    "src/"
  ]
}
```
